### PR TITLE
allow overriding find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 #
 # Global setup file for OpenVX CMake
-
 #
 cmake_minimum_required(VERSION 3.0)
 
@@ -18,7 +17,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 find_package(OpenVX)
-include_directories($ENV{C_INCLUDE_PATH})
+include_directories(${OPENVX_INCLUDES} ${VXU_INCLUDES})
 
 set(VXA_VERSION 0.1 CACHE STRING "version" FORCE)
 
@@ -26,21 +25,18 @@ set(include_dest "include/vxa")
 set(main_lib_dest "lib")
 set(headers vxa.h opencv-import.h opencv-import.hpp)
 
-include_directories($ENV{C_INCLUDE_PATH})
-
-add_library(vxa SHARED
-  opencv-import.cpp)
+add_library(vxa SHARED opencv-import.cpp)
 target_include_directories(vxa PUBLIC
   $<BUILD_INTERFACE:${MY_LIBRARY_SOURCE_DIR}> # for headers when building
 	$<INSTALL_INTERFACE:${include_dest}> # for client in install mode
   )
-target_link_libraries(vxa ${OPENVX} ${OpenCV_LIBS})
+target_link_libraries(vxa ${OPENVX_LIBRARIES} ${OpenCV_LIBS})
 
 add_executable(vxa_test1 test1.c)
-target_link_libraries(vxa_test1 ${OPENVX} vxa ${VXU} ${OpenCV_LIBS})
+target_link_libraries(vxa_test1 ${OPENVX_LIBRARIES} vxa ${VXU_LIBRARIES} ${OpenCV_LIBS})
 
 add_executable(vxa_test2 test2.c)
-target_link_libraries(vxa_test2 ${OPENVX} vxa ${OpenCV_LIBS})
+target_link_libraries(vxa_test2 ${OPENVX_LIBRARIES} vxa ${OpenCV_LIBS})
 
 install(TARGETS vxa EXPORT vxa DESTINATION "${main_lib_dest}")
 install(FILES ${headers} DESTINATION "${include_dest}")


### PR DESCRIPTION
Hi.  This PR enables overriding find_package.

Example usage
```
ExternalProject_Add(vxa
    GIT_REPOSITORY "https://github.com/relrotciv/vxa.git"
    GIT_TAG master
    GIT_SHALLOW 1
    PATCH_COMMAND ""
    UPDATE_COMMAND ""
    BUILD_IN_SOURCE 0
    LIST_SEPARATOR |
    CMAKE_ARGS
     -DANDROID_PLATFORM=${ANDROID_PLATFORM}
     -DANDROID_ABI=${ANDROID_ABI}
     -DANDROID_STL=${ANDROID_STL}
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     -DCMAKE_STAGING_PREFIX=${EXT_CMAKE_STAGING_PREFIX}
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
     -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
     -DOPENVX_FOUND=ON
     -DOPENVX_INCLUDES=${EXT_CMAKE_STAGING_PREFIX}/include
     -DOPENVX_LIBRARIES=${EXT_CMAKE_STAGING_PREFIX}/bin/libopenvx.so
     -DVXU_FOUND=ON
     -DVXU_INCLUDES=${EXT_CMAKE_STAGING_PREFIX}/include
     -DVXU_LIBRARIES=${EXT_CMAKE_STAGING_PREFIX}/bin/libvxu.so
     -DCMAKE_INSTALL_RPATH=${CMAKE_INSTALL_PREFIX}/bin${INSTALL_TRIPLE_SUFFIX}|${CMAKE_INSTALL_PREFIX}/lib${INSTALL_TRIPLE_SUFFIX}
     ${VXA_ANDROID_ARGS}
)
add_dependencies(vxa openvx-impl)
```